### PR TITLE
Misc backend tweaks and port codes

### DIFF
--- a/pypeline/preprocess.py
+++ b/pypeline/preprocess.py
@@ -79,17 +79,17 @@ class Preprocess:
             events array (as a dataframe)
         """
 
+        bids_path = mne_bids.BIDSPath(
+            subject=subject_number,
+            task=self.experiment_name,
+            root=self.data_dir,
+            datatype="eeg",
+            suffix="eeg",
+            extension=".vhdr",
+        )
+
         if not overwrite:
             try:
-                bids_path = mne_bids.BIDSPath(
-                    subject=subject_number,
-                    task=self.experiment_name,
-                    root=self.data_dir,
-                    datatype="eeg",
-                    suffix="eeg",
-                    extension=".vhdr",
-                )
-
                 eegdata = mne_bids.read_raw_bids(bids_path)
                 events = pd.read_csv(bids_path.copy().update(suffix="events", extension=".tsv").fpath, sep="\t")
 

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -118,20 +118,8 @@ class Visualizer:
             self.rej_manual = self.rej_chans.any(1)
 
         self.info = self.epochs_obj.info
-        self.chan_types = self.info.get_channel_types()
-
-        self.chan_order = np.concatenate(  # reorder channels in order EEG / EOG / eyetracking / other
-            (
-                mne.pick_types(self.info, eeg=True),
-                mne.pick_types(self.info, eog=True),
-                mne.pick_types(self.info, eyetrack="eyegaze"),
-                mne.pick_types(self.info, misc=True),
-            )
-        )
-
-        self.chan_labels = np.array(self.epochs_obj.ch_names)[self.chan_order]
-        self.rej_chans = self.rej_chans[:, self.chan_order]
-        self.chan_types = np.array(self.chan_types)[self.chan_order]
+        self.chan_types = np.array(self.info.get_channel_types())
+        self.chan_labels = np.array(self.epochs_obj.ch_names)
 
         self.channels_ignore = channels_ignore  # make a mask for channels we ignore
         self.ignored_channels_mask = np.in1d(self.chan_labels, channels_ignore)
@@ -183,8 +171,6 @@ class Visualizer:
         }  # must be in order and increasing
 
         epochs_raw = self.epochs_raw.copy()
-
-        epochs_raw = epochs_raw[:, self.chan_order]
 
         epochs_raw *= self.extra_chan_scale
 

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -473,10 +473,25 @@ class Visualizer:
             if isinstance(child, Annotation) and text in child.get_text():
                 child.remove()
 
-    def show_port_codes(self, show=True):
+    def show_port_codes(self):
         """
-        Function to show port codes
+        Function to show port codes for trials on screen
         """
+
+        self.code_annotations = []
+        all_codes = []
+        all_times = []
+        for i in range(self.win_step):
+            times = self.all_times[self.slider.val + i]
+            all_times.extend([t + i * self.epoch_len for t in times])
+            all_codes.extend(self.all_codes[self.slider.val + i])
+
+        self.ax.vlines(all_times, *self.ylim, color="g")
+
+        for code, time in zip(all_codes, all_times):
+            an = self.ax.annotate(code, (time, self.ylim[1] + 5e-6), ha="center", annotation_clip=False)
+            self.code_annotations.append(an)
+        self.fig.canvas.draw_idle()
 
     def update(self, force=False):
         pos = self.slider.val

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -32,6 +32,7 @@ class Visualizer:
         chan_offset=CHAN_OFFSET,
         channels_drop=None,
         channels_ignore=None,
+        load_flags=True,
     ):
         self.sub = sub
         self.parent_dir = parent_dir
@@ -93,7 +94,12 @@ class Visualizer:
             self.rej_chans[:, self.ignored_channels_mask] = False
             self.rej_reasons[:, self.ignored_channels_mask] = None
 
-        self.rej_manual = self.rej_chans.any(1)
+        if load_flags:
+            self.data_path.update(suffix="rejection_flags", extension=".npy")
+            print("You have saved annotations already. Loading these.")
+            self.rej_manual = np.load(self.data_path.fpath)
+        else:
+            self.rej_manual = self.rej_chans.any(1)
 
         self.info = self.epochs_obj.info
         self.chan_types = self.info.get_channel_types()


### PR DESCRIPTION
Enhancements to data import functionality:

* [`pypeline/preprocess.py`](diffhunk://#diff-bf5aef40caca64a75844529ef3494079ddd632f46e172977aae445f232219a73L73-R98): Added an `overwrite` parameter to the `import_eeg` and `import_eyetracker` functions to allow re-importing data if it already exists. Previously, data would always be overwritten. Now, if  if `overwrite` is set to `False` it will just read the existing imported dataset. (Fixes #16) [[1]](diffhunk://#diff-bf5aef40caca64a75844529ef3494079ddd632f46e172977aae445f232219a73L73-R98) [[2]](diffhunk://#diff-bf5aef40caca64a75844529ef3494079ddd632f46e172977aae445f232219a73R208-R237). 


Enhancements to visualizer features:

* [`pypeline/visualizer.py`](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cR35): Added the ability to load previously saved rejection flags and annotations (Fixes #15), and introduced new options to show port codes in the GUI (p hotkey). Also, fixed a bug such that when rejection reasons or port codes are toggled on this persists across page changes (Fixes #20). [[1]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cR35) [[2]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cL59-R109) [[3]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cL92-R137) [[4]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cR267) [[5]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cL486-R558). 



### Code cleanup and refactoring:
* fixed a minor bug to ensure that non-EEG channels are not bandpass filtered (`pypeline/preprocess.py`) [[1]](diffhunk://#diff-bf5aef40caca64a75844529ef3494079ddd632f46e172977aae445f232219a73L445-L446) 
* Removed code that reorders epoch objects based on channel type as it is not exactly necessary for any functionality. (`pypeline/visualizer.py`) [[1]](diffhunk://#diff-05909103eccf7a28d8b4ed760bd58911ee5d29dd0e20dd83c2532bac6b5aa35cL148-L149)
