### PR TITLE
22 variable length epochs

### DIFF
--- a/pypeline/preprocess.py
+++ b/pypeline/preprocess.py
@@ -276,8 +276,7 @@ class Preprocess:
                 if len(asc_file) == 0:
                     raise FileNotFoundError("No .asc file. I will try to re-import the data")
                 elif len(asc_file) == 1:
-                    asc_file = os.path.join(subject_dir, asc_file[0])
-                    eye = mne.io.read_raw_eyelink(asc_file, create_annotations=["blinks", "messages"])
+                    eye = mne.io.read_raw_eyelink(path.fpath, create_annotations=["blinks", "messages"])
 
                 else:
                     print(
@@ -285,7 +284,7 @@ class Preprocess:
                     )
                     raws = []
                     for ifile, file in enumerate(asc_file):
-                        file = os.path.join(subject_dir, file)
+                        file = os.path.join(path.fpath.parent, file)
                         ascpath = path.copy().update(split=ifile + 1)
                         raws.append(mne.io.read_raw_eyelink(file, create_annotations=["blinks", "messages"]))
                     eye = mne.concatenate_raws(raws)
@@ -296,7 +295,8 @@ class Preprocess:
 
                 return eye, eye_events
 
-            except FileNotFoundError:
+            except FileNotFoundError as e:
+                print(e)
                 print("Could not find Eyetracking data in your directory. I will try to import it from the raw data")
 
         path.mkdir()

--- a/pypeline/preprocess.py
+++ b/pypeline/preprocess.py
@@ -842,8 +842,10 @@ class Preprocess:
                 np.diff(  # see if the gap between indices is bigger than the duration
                     np.where(  # find the indices of non-flat moments
                         np.concatenate(
-                            ([True], non_flats, [True])
-                        )  # add True to the beginning and end of the array, to avoid unbounded runs of flats
+                            # add True to the beginning and end of the array, to avoid unbounded runs of flats
+                            # also converts masked values to True, so they are non considered flat
+                            ([True], non_flats.filled(True), [True])
+                        )
                     )[0]
                 )
                 >= duration

--- a/pypeline/preprocess.py
+++ b/pypeline/preprocess.py
@@ -774,7 +774,9 @@ class Preprocess:
 
                 first_half = np.nanmean(eegdata[:, chans, st : st + win // 2], axis=2)
                 last_half = np.nanmean(eegdata[:, chans, st + win // 2 : st + win], axis=2)
-                rej_chans[:, chans] = np.logical_or(rej_chans[:, chans], np.abs(first_half - last_half) > threshold)
+                reject = np.abs(first_half - last_half) > threshold
+                reject = reject.filled(False)  # fill masked values with False so they aren't rejected
+                rej_chans[:, chans] = np.logical_or(rej_chans[:, chans], reject)
 
         # if both eyes are recorded, then ONLY mark artifacts if they appear in both eyes
         rej_chans = self._check_both_eyes(epochs.ch_names, rej_chans)

--- a/pypeline/preprocess.py
+++ b/pypeline/preprocess.py
@@ -36,7 +36,7 @@ class Preprocess:
         baseline_time: tuple[float, float] | None = None,  # times for baselining
         rejection_time: tuple[float, float] | None = None,  # times to do rejection
         reject_between_codes: tuple | None = None,  # reject trials between these codes
-        drop_channels=None,  # channels to drop outright (not recommendedd)
+        drop_channels=None,  # channels to drop outright (not recommended)
         experiment_name=None,  # name of your experiment
     ):
 

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -33,6 +33,7 @@ class Visualizer:
         load_flags: bool = True,
         port_codes_show: list | None = None,  # list of port codes to show, if None then all are shown
     ):
+
         self.sub = sub
         self.parent_dir = parent_dir
         self.experiment_name = experiment_name
@@ -67,10 +68,22 @@ class Visualizer:
         self.events = pd.read_csv(self.data_path.fpath, sep="\t")
 
         ## EEG Port codes from metadata
+        if port_codes_show is None:
+            events_show = list(self.epochs_obj.event_id.keys())  # show all port codes
+        else:
+            events_show = []
+            for code in port_codes_show:
+                if code in self.epochs_obj.event_id.keys():
+                    events_show.append(code)
+                elif code in self.epochs_obj.event_id.values():
+                    events_show.append(
+                        list(self.epochs_obj.event_id.keys())[list(self.epochs_obj.event_id.values()).index(code)]
+                    )  # get corresponding event id
+
         self.all_port_codes = []
         self.all_portcode_times = []
         for _, row in self.epochs_obj.metadata.iterrows():
-            row = row.dropna()
+            row = row[events_show].dropna()  # only keep events we want to display
             row = row[np.logical_and(row > self.trial_start, row < self.trial_end)]
             row.sort_values(inplace=True)
             self.all_port_codes.append(

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -385,7 +385,7 @@ class Visualizer:
         # Plot time labels
 
         if self.rejection_time[0] == self.trial_start and self.rejection_time[1] == self.trial_end:
-            pass
+            self.ax.set_xticks([])
         elif self.rejection_time[0] == self.trial_start:
             self.ax.set_xticks(
                 np.arange(

--- a/pypeline/visualizer.py
+++ b/pypeline/visualizer.py
@@ -26,13 +26,14 @@ class Visualizer:
         trial_start: float,
         trial_end: float,
         experiment_name: str,
-        rejection_time=(None, None),
+        rejection_time: tuple[float | None, float | None] = (None, None),
         win_step: int = SLIDER_STEP,
-        downscale={"eyegaze": EYETRACK_SCALE},
-        chan_offset=CHAN_OFFSET,
-        channels_drop=None,
-        channels_ignore=None,
-        load_flags=True,
+        downscale: dict = {"eyegaze": EYETRACK_SCALE},
+        chan_offset: float = CHAN_OFFSET,
+        channels_drop: list = None,
+        channels_ignore: list = None,
+        load_flags: bool = True,
+        port_codes_show: list | None = None,  # list of port codes to show, if None then all are shown
     ):
         self.sub = sub
         self.parent_dir = parent_dir
@@ -83,6 +84,9 @@ class Visualizer:
                 & (all_port_codes["sample"] < trial_sample + self.trial_end * 1000)
             ]
             # get codes which occured in a (trial_start, trial_end) sample around each trial's timelock event
+
+            if port_codes_show is not None:
+                trial_codes = trial_codes[trial_codes["value"].isin(port_codes_show)]
             code_times = np.array(trial_codes["sample"])
             code_times -= trial_sample
             code_times -= int(self.trial_start * 1000)


### PR DESCRIPTION
* Introduced `timelock_ix` parameter to support flexible trial-locking configurations, allowing users to specify either a global index (eg, always code 1), or condition-specific indices as a dict.
* Added support for setting rejection period for trials based on event codes (`reject_between_codes`) in addition to time ranges (`rejection_time`)
* `_get_data_from_rej_period` will now return a masked array when using event code based rejection. Updated `artreject_slidingP2P` and `artreject_linear` to handle this properly
* Added `_make_metadata_from_events` to generate metadata for EEG epochs using event data. This contains other port codes associated with the trial, and is attached to the epochs object
